### PR TITLE
Enh : Rename plugins

### DIFF
--- a/plugins/plugin-check-amt-montreal/debian/changelog
+++ b/plugins/plugin-check-amt-montreal/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-amt-montreal (2014.7.17.9.36-1) unstable; urgency=low
+monitoring-plugins-sfl-amt-montreal (2014.7.17.9.36-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-amt-montreal/debian/control
+++ b/plugins/plugin-check-amt-montreal/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-amt-montreal
+Source: monitoring-plugins-sfl-amt-montreal
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-amt-montreal
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-amt-montreal.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-amt-montreal.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-amt-montreal
+Package: monitoring-plugins-sfl-amt-montreal
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-protobuf
 Description: Checks the numbers of warnings reported by the AMT trains in the Montreal area.

--- a/plugins/plugin-check-amt-montreal/debian/copyright
+++ b/plugins/plugin-check-amt-montreal/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-amt-montreal
-Source: <https://github.com/savoirfairelinux/plugin-check-amt-montreal>
+Upstream-Name: monitoring-plugins-sfl-amt-montreal
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-amt-montreal>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-amt-montreal/doc/plugin-check_amt_montreal.rst
+++ b/plugins/plugin-check-amt-montreal/doc/plugin-check_amt_montreal.rst
@@ -1,4 +1,4 @@
-plugin-check-amt-montreal
-=========================
+monitoring-plugins-sfl-amt-montreal
+===================================
 
 Checks the numbers of warnings reported by the AMT trains in the Montreal area.

--- a/plugins/plugin-check-arp-no-change/debian/changelog
+++ b/plugins/plugin-check-arp-no-change/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-arp-no-change (2014.9.25.14.24-1) unstable; urgency=low
+monitoring-plugins-sfl-arp-no-change (2014.9.25.14.24-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-arp-no-change/debian/control
+++ b/plugins/plugin-check-arp-no-change/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-arp-no-change
+Source: monitoring-plugins-sfl-arp-no-change
 Section: python
 Priority: optional
 Maintainer: Grégory Starck <gregory.starck@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-arp-no-change
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-arp-no-change.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-arp-no-change.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-arp-no-change
+Package: monitoring-plugins-sfl-arp-no-change
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Verify that a host MAC addresse doesn't change

--- a/plugins/plugin-check-arp-no-change/debian/copyright
+++ b/plugins/plugin-check-arp-no-change/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-arp-no-change
-Source: <https://github.com/savoirfairelinux/plugin-check-arp-no-change>
+Upstream-Name: monitoring-plugins-sfl-arp-no-change
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-arp-no-change>
 
 Files: *
 Copyright: Copyright (C) 2014 Grégory Starck

--- a/plugins/plugin-check-arp-no-change/doc/plugin-check_arp_no_change.rst
+++ b/plugins/plugin-check-arp-no-change/doc/plugin-check_arp_no_change.rst
@@ -1,4 +1,4 @@
-plugin-check-arp-no-change
-==========================
+monitoring-plugins-sfl-arp-no-change
+====================================
 
 Verify that a host MAC addresse doesn't change

--- a/plugins/plugin-check-asterisk-cdr-status/debian/changelog
+++ b/plugins/plugin-check-asterisk-cdr-status/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-asterisk-cdr-status (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-asterisk-cdr-status (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-asterisk-cdr-status/debian/control
+++ b/plugins/plugin-check-asterisk-cdr-status/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-asterisk-cdr-status
+Source: monitoring-plugins-sfl-asterisk-cdr-status
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-asterisk-cdr-status
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-asterisk-cdr-status.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-asterisk-cdr-status.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-asterisk-cdr-status
+Package: monitoring-plugins-sfl-asterisk-cdr-status
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check asterisk sql cdr

--- a/plugins/plugin-check-asterisk-cdr-status/debian/copyright
+++ b/plugins/plugin-check-asterisk-cdr-status/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-asterisk-cdr-status
-Source: <https://github.com/savoirfairelinux/plugin-check-asterisk-cdr-status>
+Upstream-Name: monitoring-plugins-sfl-asterisk-cdr-status
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-asterisk-cdr-status>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc. 

--- a/plugins/plugin-check-asterisk-cdr-status/doc/plugin-check_asterisk_cdr_status.rst
+++ b/plugins/plugin-check-asterisk-cdr-status/doc/plugin-check_asterisk_cdr_status.rst
@@ -1,4 +1,4 @@
-plugin-check-asterisk-cdr-status
-================================
+monitoring-plugins-sfl-asterisk-cdr-status
+==========================================
 
 Shinken plugin from SFL. Check asterisk sql cdr

--- a/plugins/plugin-check-aws-sqs-activity/debian/changelog
+++ b/plugins/plugin-check-aws-sqs-activity/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-aws-sqs-activity (2014.8.4.10.13-1) unstable; urgency=low
+monitoring-plugins-sfl-aws-sqs-activity (2014.8.4.10.13-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-aws-sqs-activity/debian/control
+++ b/plugins/plugin-check-aws-sqs-activity/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-aws-sqs-activity
+Source: monitoring-plugins-sfl-aws-sqs-activity
 Section: python
 Priority: optional
 Maintainer: Alexandre Viau <alexandre@alexandreviau.net>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-aws-sqs-activity
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-aws-sqs-activity.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-aws-sqs-activity.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-aws-sqs-activity
+Package: monitoring-plugins-sfl-aws-sqs-activity
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Checks the activity of AWS's simple queue service.

--- a/plugins/plugin-check-aws-sqs-activity/debian/copyright
+++ b/plugins/plugin-check-aws-sqs-activity/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-aws-sqs-activity
-Source: <https://github.com/savoirfairelinux/plugin-check-aws-sqs-activity>
+Upstream-Name: monitoring-plugins-sfl-aws-sqs-activity
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-aws-sqs-activity>
 
 Files: *
 Copyright: Copyright (C) 2014 Alexandre Viau

--- a/plugins/plugin-check-aws-sqs-activity/doc/plugin-check_aws_sqs_activity.rst
+++ b/plugins/plugin-check-aws-sqs-activity/doc/plugin-check_aws_sqs_activity.rst
@@ -1,4 +1,4 @@
-plugin-check-aws-sqs-activity
-=============================
+monitoring-plugins-sfl-aws-sqs-activity
+=======================================
 
 Checks the activity of AWS's simple queue service.

--- a/plugins/plugin-check-aws-sqs-queue-size/debian/changelog
+++ b/plugins/plugin-check-aws-sqs-queue-size/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-aws-sqs-queue-size (2014.8.4.12.23-1) unstable; urgency=low
+monitoring-plugins-sfl-aws-sqs-queue-size (2014.8.4.12.23-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-aws-sqs-queue-size/debian/control
+++ b/plugins/plugin-check-aws-sqs-queue-size/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-aws-sqs-queue-size
+Source: monitoring-plugins-sfl-aws-sqs-queue-size
 Section: python
 Priority: optional
 Maintainer: Alexandre Viau <alexandre.viau@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-aws-sqs-queue-size
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-aws-sqs-queue-size.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-aws-sqs-queue-size.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-aws-sqs-queue-size
+Package: monitoring-plugins-sfl-aws-sqs-queue-size
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Checks the size of an AWS sqs queue

--- a/plugins/plugin-check-aws-sqs-queue-size/debian/copyright
+++ b/plugins/plugin-check-aws-sqs-queue-size/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-aws-sqs-queue-size
-Source: <https://github.com/savoirfairelinux/plugin-check-aws-sqs-queue-size>
+Upstream-Name: monitoring-plugins-sfl-aws-sqs-queue-size
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-aws-sqs-queue-size>
 
 Files: *
 Copyright: Copyright (C) 2014 Alexandre Viau

--- a/plugins/plugin-check-aws-sqs-queue-size/doc/plugin-check_aws_sqs_queue_size.rst
+++ b/plugins/plugin-check-aws-sqs-queue-size/doc/plugin-check_aws_sqs_queue_size.rst
@@ -1,4 +1,4 @@
-plugin-check-aws-sqs-queue-size
-===============================
+monitoring-plugins-sfl-aws-sqs-queue-size
+=========================================
 
 Checks the size of an AWS sqs queue

--- a/plugins/plugin-check-bixi-montreal/debian/changelog
+++ b/plugins/plugin-check-bixi-montreal/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-bixi-montreal (2014.7.17.16.37-1) unstable; urgency=low
+monitoring-plugins-sfl-bixi-montreal (2014.7.17.16.37-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-bixi-montreal/debian/control
+++ b/plugins/plugin-check-bixi-montreal/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-bixi-montreal
+Source: monitoring-plugins-sfl-bixi-montreal
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-bixi-montreal
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-bixi-montreal.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-bixi-montreal.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-bixi-montreal
+Package: monitoring-plugins-sfl-bixi-montreal
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: Checks empty or full Bixi (public bike service) stations, in Montreal.

--- a/plugins/plugin-check-bixi-montreal/debian/copyright
+++ b/plugins/plugin-check-bixi-montreal/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-bixi-montreal
-Source: <https://github.com/savoirfairelinux/plugin-check-bixi-montreal>
+Upstream-Name: monitoring-plugins-sfl-bixi-montreal
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-bixi-montreal>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-bixi-montreal/doc/plugin-check_bixi_montreal.rst
+++ b/plugins/plugin-check-bixi-montreal/doc/plugin-check_bixi_montreal.rst
@@ -1,4 +1,4 @@
-plugin-check-bixi-montreal
-==========================
+monitoring-plugins-sfl-bixi-montreal
+====================================
 
 Checks empty or full Bixi (public bike service) stations, in Montreal.

--- a/plugins/plugin-check-brother-toner-level/debian/changelog
+++ b/plugins/plugin-check-brother-toner-level/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-brother-toner-level (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-brother-toner-level (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-brother-toner-level/debian/control
+++ b/plugins/plugin-check-brother-toner-level/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-brother-toner-level
+Source: monitoring-plugins-sfl-brother-toner-level
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-brother-toner-level
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-brother-toner-level.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-brother-toner-level.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-brother-toner-level
+Package: monitoring-plugins-sfl-brother-toner-level
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-lxml
 Description: Shinken plugin from SFL. Check toner levels of Brother printer by http

--- a/plugins/plugin-check-brother-toner-level/debian/copyright
+++ b/plugins/plugin-check-brother-toner-level/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-brother-toner-level
-Source: <https://github.com/savoirfairelinux/plugin-check-brother-toner-level>
+Upstream-Name: monitoring-plugins-sfl-brother-toner-level
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-brother-toner-level>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-brother-toner-level/doc/plugin-check_brother_toner_level.rst
+++ b/plugins/plugin-check-brother-toner-level/doc/plugin-check_brother_toner_level.rst
@@ -1,4 +1,4 @@
-plugin-check-brother-toner-level
-================================
+monitoring-plugins-sfl-brother-toner-level
+==========================================
 
 Shinken plugin from SFL. Check toner levels of Brother printer by http

--- a/plugins/plugin-check-brother-toner-level/requests/debian/control
+++ b/plugins/plugin-check-brother-toner-level/requests/debian/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 114-6847372-1
 Build-Depends: debhelper (>= 7)
-Homepage: http://www.savoirfairelinux.com
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
 
 Package: python-requests
 Architecture: any

--- a/plugins/plugin-check-brother-toner-level/requests/debian/python-requests/DEBIAN/control
+++ b/plugins/plugin-check-brother-toner-level/requests/debian/python-requests/DEBIAN/control
@@ -6,5 +6,5 @@ Installed-Size: 884
 Depends: python
 Section: misc
 Priority: optional
-Homepage: http://www.savoirfairelinux.com
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
 Description: Python requests SFL lib

--- a/plugins/plugin-check-carp-by-ssh/debian/changelog
+++ b/plugins/plugin-check-carp-by-ssh/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-carp-by-ssh (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-carp-by-ssh (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-carp-by-ssh/debian/control
+++ b/plugins/plugin-check-carp-by-ssh/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-carp-by-ssh
+Source: monitoring-plugins-sfl-carp-by-ssh
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-carp-by-ssh
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-carp-by-ssh.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-carp-by-ssh.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-carp-by-ssh
+Package: monitoring-plugins-sfl-carp-by-ssh
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check carp status on Soekris using ssh

--- a/plugins/plugin-check-carp-by-ssh/debian/copyright
+++ b/plugins/plugin-check-carp-by-ssh/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-carp-by-ssh
-Source: <https://github.com/savoirfairelinux/plugin-check-carp-by-ssh>
+Upstream-Name: monitoring-plugins-sfl-carp-by-ssh
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-carp-by-ssh>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc. 

--- a/plugins/plugin-check-carp-by-ssh/doc/plugin-check_carp_by_ssh.rst
+++ b/plugins/plugin-check-carp-by-ssh/doc/plugin-check_carp_by_ssh.rst
@@ -1,4 +1,4 @@
-plugin-check-carp-by-ssh
-========================
+monitoring-plugins-sfl-carp-by-ssh
+==================================
 
 Shinken plugin from SFL. Check carp status on Soekris using ssh

--- a/plugins/plugin-check-ceilometer/README.md
+++ b/plugins/plugin-check-ceilometer/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/savoirfairelinux/plugin-check_ceilometer.svg?branch=master)](https://travis-ci.org/savoirfairelinux/plugin-check_ceilometer) [![Coverage Status](https://img.shields.io/coveralls/savoirfairelinux/check_ceilometer.svg)](https://coveralls.io/r/savoirfairelinux/plugin-check_ceilometer?branch=coveralls)
+[![Build Status](https://travis-ci.org/savoirfairelinux/monitoring-plugins-sfl_ceilometer.svg?branch=master)](https://travis-ci.org/savoirfairelinux/monitoring-plugins-sfl_ceilometer) [![Coverage Status](https://img.shields.io/coveralls/savoirfairelinux/check_ceilometer.svg)](https://coveralls.io/r/savoirfairelinux/monitoring-plugins-sfl_ceilometer?branch=coveralls)
 
 
 A Nagios plug-in to use OpenStack Ceilometer API for metering

--- a/plugins/plugin-check-ceilometer/debian/changelog
+++ b/plugins/plugin-check-ceilometer/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-ceilometer (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-ceilometer (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-ceilometer/debian/control
+++ b/plugins/plugin-check-ceilometer/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-ceilometer
+Source: monitoring-plugins-sfl-ceilometer
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-ceilometer
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-ceilometer.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-ceilometer.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-ceilometer
+Package: monitoring-plugins-sfl-ceilometer
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-keystoneclient, python-ceilometerclient
 Description: Shinken plugin from SFL. A Nagios plug-in to use OpenStack Ceilometer API for metering

--- a/plugins/plugin-check-ceilometer/debian/copyright
+++ b/plugins/plugin-check-ceilometer/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-ceilometer
-Source: <https://github.com/savoirfairelinux/plugin-check-ceilometer>
+Upstream-Name: monitoring-plugins-sfl-ceilometer
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-ceilometer>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-ceilometer/doc/plugin-check_ceilometer.rst
+++ b/plugins/plugin-check-ceilometer/doc/plugin-check_ceilometer.rst
@@ -1,4 +1,4 @@
-plugin-check-ceilometer
-=======================
+monitoring-plugins-sfl-ceilometer
+=================================
 
 Shinken plugin from SFL. A Nagios plug-in to use OpenStack Ceilometer API for metering

--- a/plugins/plugin-check-cpu/debian/changelog
+++ b/plugins/plugin-check-cpu/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-cpu (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-cpu (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-cpu/debian/control
+++ b/plugins/plugin-check-cpu/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-cpu
+Source: monitoring-plugins-sfl-cpu
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-cpu
-Vcs-Git: git://github.com/savoirfairelinux/plugin-check-cpu.git
-Vcs-Browser: https://github.com/savoirfairelinux/plugin-check-cpu
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-cpu
+Package: monitoring-plugins-sfl-cpu
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, bc
 Description: Shinken plugin from SFL. check CPU usage

--- a/plugins/plugin-check-cpu/debian/copyright
+++ b/plugins/plugin-check-cpu/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-cpu
-Source: <https://github.com/savoirfairelinux/plugin-check-cpu>
+Upstream-Name: monitoring-plugins-sfl-cpu
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-cpu>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-cpu/doc/plugin-check_cpu.rst
+++ b/plugins/plugin-check-cpu/doc/plugin-check_cpu.rst
@@ -1,3 +1,3 @@
-plugin-check_cpu
-================
+monitoring-plugins-sfl-cpu
+==========================
 Shinken plugin from SFL. check CPU usage

--- a/plugins/plugin-check-emergency-rooms-quebec/debian/changelog
+++ b/plugins/plugin-check-emergency-rooms-quebec/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-emergency-rooms-quebec (2014.7.18.9.51-1) unstable; urgency=low
+monitoring-plugins-sfl-emergency-rooms-quebec (2014.7.18.9.51-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-emergency-rooms-quebec/debian/control
+++ b/plugins/plugin-check-emergency-rooms-quebec/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-emergency-rooms-quebec
+Source: monitoring-plugins-sfl-emergency-rooms-quebec
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-emergency-rooms-quebec
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-emergency-rooms-quebec.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-emergency-rooms-quebec.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-emergency-rooms-quebec
+Package: monitoring-plugins-sfl-emergency-rooms-quebec
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: Checks the occupation of stretchers in various hospitals in Quebec.

--- a/plugins/plugin-check-emergency-rooms-quebec/debian/copyright
+++ b/plugins/plugin-check-emergency-rooms-quebec/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-emergency-rooms-quebec
-Source: <https://github.com/savoirfairelinux/plugin-check-emergency-rooms-quebec>
+Upstream-Name: monitoring-plugins-sfl-emergency-rooms-quebec
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-emergency-rooms-quebec>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-emergency-rooms-quebec/doc/plugin-check_emergency_rooms_quebec.rst
+++ b/plugins/plugin-check-emergency-rooms-quebec/doc/plugin-check_emergency_rooms_quebec.rst
@@ -1,5 +1,5 @@
-plugin-check-emergency-rooms-quebec
-===================================
+monitoring-plugins-sfl-emergency-rooms-quebec
+=============================================
 
 Checks the occupation of stretchers in various hospitals in Quebec.
 

--- a/plugins/plugin-check-environment-canada/debian/changelog
+++ b/plugins/plugin-check-environment-canada/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-environment-canada (2014.7.18.10.45-1) unstable; urgency=low
+monitoring-plugins-sfl-environment-canada (2014.7.18.10.45-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-environment-canada/debian/control
+++ b/plugins/plugin-check-environment-canada/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-environment-canada
+Source: monitoring-plugins-sfl-environment-canada
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-environment-canada
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-environment-canada.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-environment-canada.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-environment-canada
+Package: monitoring-plugins-sfl-environment-canada
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Checks various environment metrics in Canada.

--- a/plugins/plugin-check-environment-canada/debian/copyright
+++ b/plugins/plugin-check-environment-canada/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-environment-canada
-Source: <https://github.com/savoirfairelinux/plugin-check-environment-canada>
+Upstream-Name: monitoring-plugins-sfl-environment-canada
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-environment-canada>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-environment-canada/doc/plugin-check_environment_canada.rst
+++ b/plugins/plugin-check-environment-canada/doc/plugin-check_environment_canada.rst
@@ -1,4 +1,4 @@
-plugin-check-environment-canada
-===============================
+monitoring-plugins-sfl-environment-canada
+=========================================
 
 Checks various environment metrics in Canada.

--- a/plugins/plugin-check-fake/debian/changelog
+++ b/plugins/plugin-check-fake/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-fake (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-fake (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-fake/debian/control
+++ b/plugins/plugin-check-fake/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-fake
+Source: monitoring-plugins-sfl-fake
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-fake
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-fake.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-fake.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-fake
+Package: monitoring-plugins-sfl-fake
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Fake plugin

--- a/plugins/plugin-check-fake/debian/copyright
+++ b/plugins/plugin-check-fake/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-fake
-Source: <https://github.com/savoirfairelinux/plugin-check-fake>
+Upstream-Name: monitoring-plugins-sfl-fake
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-fake>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-fake/doc/plugin-check_fake.rst
+++ b/plugins/plugin-check-fake/doc/plugin-check_fake.rst
@@ -1,4 +1,4 @@
-plugin-check-fake
-=================
+monitoring-plugins-sfl-fake
+===========================
 
 Shinken plugin from SFL. Fake plugin

--- a/plugins/plugin-check-graphite-api/debian/changelog
+++ b/plugins/plugin-check-graphite-api/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-graphite-api (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-graphite-api (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-graphite-api/debian/control
+++ b/plugins/plugin-check-graphite-api/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-graphite-api
+Source: monitoring-plugins-sfl-graphite-api
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-graphite-api
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-graphite-api.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-graphite-api.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-graphite-api
+Package: monitoring-plugins-sfl-graphite-api
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: This plugin is made to ensure data freshness into Graphite.

--- a/plugins/plugin-check-graphite-api/debian/copyright
+++ b/plugins/plugin-check-graphite-api/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-graphite-api
-Source: <https://github.com/savoirfairelinux/plugin-check-graphite-api>
+Upstream-Name: monitoring-plugins-sfl-graphite-api
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-graphite-api>
 
 Files: *
 Copyright: Copyright (C) 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-graphite-api/doc/plugin-check_graphite_api.rst
+++ b/plugins/plugin-check-graphite-api/doc/plugin-check_graphite_api.rst
@@ -1,5 +1,5 @@
-plugin-check-graphite-api
-=========================
+monitoring-plugins-sfl-graphite-api
+===================================
 
 Shinken plugin from SFL.
 

--- a/plugins/plugin-check-http2/debian/changelog
+++ b/plugins/plugin-check-http2/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-http2 (2014.7.18.16.15-1) unstable; urgency=low
+monitoring-plugins-sfl-http2 (2014.7.18.16.15-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-http2/debian/control
+++ b/plugins/plugin-check-http2/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-http2
+Source: monitoring-plugins-sfl-http2
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-http2
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-http2.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-http2.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-http2
+Package: monitoring-plugins-sfl-http2
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Checks HTTP sites, and doesn't timeout like good'old check_http.

--- a/plugins/plugin-check-http2/debian/copyright
+++ b/plugins/plugin-check-http2/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-http2
-Source: <https://github.com/savoirfairelinux/plugin-check-http2>
+Upstream-Name: monitoring-plugins-sfl-http2
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-http2>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-http2/doc/plugin-check_http2.rst
+++ b/plugins/plugin-check-http2/doc/plugin-check_http2.rst
@@ -1,4 +1,4 @@
-plugin-check-http2
-==================
+monitoring-plugins-sfl-http2
+============================
 
 Checks HTTP sites, and doesn't timeout like good'old check_http.

--- a/plugins/plugin-check-hydro-quebec/debian/changelog
+++ b/plugins/plugin-check-hydro-quebec/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-hydro-quebec (2014.9.9.11.48-1) unstable; urgency=low
+monitoring-plugins-sfl-hydro-quebec (2014.9.9.11.48-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-hydro-quebec/debian/control
+++ b/plugins/plugin-check-hydro-quebec/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-hydro-quebec
+Source: monitoring-plugins-sfl-hydro-quebec
 Section: python
 Priority: optional
 Maintainer: vdnguyen <vanduc.nguyen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-hydro-quebec
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-hydro-quebec.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-hydro-quebec.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-hydro-quebec
+Package: monitoring-plugins-sfl-hydro-quebec
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: surveiller le nombre de pannes

--- a/plugins/plugin-check-hydro-quebec/debian/copyright
+++ b/plugins/plugin-check-hydro-quebec/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-hydro-quebec
-Source: <https://github.com/savoirfairelinux/plugin-check-hydro-quebec>
+Upstream-Name: monitoring-plugins-sfl-hydro-quebec
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-hydro-quebec>
 
 Files: *
 Copyright: Copyright (C) 2014 vdnguyen

--- a/plugins/plugin-check-hydro-quebec/doc/plugin-check_hydro_quebec.rst
+++ b/plugins/plugin-check-hydro-quebec/doc/plugin-check_hydro_quebec.rst
@@ -1,4 +1,4 @@
-plugin-check-hydro-quebec
-=========================
+monitoring-plugins-sfl-hydro-quebec
+===================================
 
 Get the number of service problems

--- a/plugins/plugin-check-json-by-ec2-tags/debian/changelog
+++ b/plugins/plugin-check-json-by-ec2-tags/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-json-by-ec2-tags (2014.8.1.14.51-1) unstable; urgency=low
+monitoring-plugins-sfl-json-by-ec2-tags (2014.8.1.14.51-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-json-by-ec2-tags/debian/control
+++ b/plugins/plugin-check-json-by-ec2-tags/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-json-by-ec2-tags
+Source: monitoring-plugins-sfl-json-by-ec2-tags
 Section: python
 Priority: optional
 Maintainer: Alexandre Viau <alexandre.viau@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-json-by-ec2-tags
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-json-by-ec2-tags.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-json-by-ec2-tags.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-json-by-ec2-tags
+Package: monitoring-plugins-sfl-json-by-ec2-tags
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-boto, python-requests
 Description: Runs check-json on all AWS ec2 instances with a particular tag.

--- a/plugins/plugin-check-json-by-ec2-tags/debian/copyright
+++ b/plugins/plugin-check-json-by-ec2-tags/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-json-by-ec2-tags
-Source: <https://github.com/savoirfairelinux/plugin-check-json-by-ec2-tags>
+Upstream-Name: monitoring-plugins-sfl-json-by-ec2-tags
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-json-by-ec2-tags>
 
 Files: *
 Copyright: Copyright (C) 2014 Alexandre Viau

--- a/plugins/plugin-check-json-by-ec2-tags/doc/plugin-check_json_by_ec2_tags.rst
+++ b/plugins/plugin-check-json-by-ec2-tags/doc/plugin-check_json_by_ec2_tags.rst
@@ -1,4 +1,4 @@
-plugin-check-json-by-ec2-tags
-=============================
+monitoring-plugins-sfl-json-by-ec2-tags
+=======================================
 
 Runs check-json on all AWS ec2 instances with a particular tag.

--- a/plugins/plugin-check-libvirt-stats/debian/changelog
+++ b/plugins/plugin-check-libvirt-stats/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-libvirt-stats (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-libvirt-stats (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-libvirt-stats/debian/control
+++ b/plugins/plugin-check-libvirt-stats/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-libvirt-stats
+Source: monitoring-plugins-sfl-libvirt-stats
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-libvirt-stats
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-libvirt-stats.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-libvirt-stats.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-libvirt-stats
+Package: monitoring-plugins-sfl-libvirt-stats
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-libvirt
 Description: Shinken plugin from SFL. Guest and host statistics from libvirt API

--- a/plugins/plugin-check-libvirt-stats/debian/copyright
+++ b/plugins/plugin-check-libvirt-stats/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-libvirt-stats
-Source: <https://github.com/savoirfairelinux/plugin-check-libvirt-stats>
+Upstream-Name: monitoring-plugins-sfl-libvirt-stats
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-libvirt-stats>
 
 Files: *
 Copyright: 2012, 2013 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-libvirt-stats/doc/plugin-check_libvirt_stats.rst
+++ b/plugins/plugin-check-libvirt-stats/doc/plugin-check_libvirt_stats.rst
@@ -1,4 +1,4 @@
-plugin-check-libvirt-stats
-==========================
+monitoring-plugins-sfl-libvirt-stats
+====================================
 
 Shinken plugin from SFL. Guest and host statistics from libvirt API

--- a/plugins/plugin-check-linux-bandwidth/debian/changelog
+++ b/plugins/plugin-check-linux-bandwidth/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-linux-bandwidth (2014.11.4.9.42-1) unstable; urgency=low
+monitoring-plugins-sfl-linux-bandwidth (2014.11.4.9.42-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-linux-bandwidth/debian/control
+++ b/plugins/plugin-check-linux-bandwidth/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-linux-bandwidth
+Source: monitoring-plugins-sfl-linux-bandwidth
 Section: python
 Priority: optional
 Maintainer: vdnguyen <vanduc.nguyen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-linux-bandwidth
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-linux-bandwidth.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-linux-bandwidth.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-linux-bandwidth
+Package: monitoring-plugins-sfl-linux-bandwidth
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: check usage bandwidth per month

--- a/plugins/plugin-check-linux-bandwidth/debian/copyright
+++ b/plugins/plugin-check-linux-bandwidth/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-linux-bandwidth
-Source: <https://github.com/savoirfairelinux/plugin-check-linux-bandwidth>
+Upstream-Name: monitoring-plugins-sfl-linux-bandwidth
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-linux-bandwidth>
 
 Files: *
 Copyright: Copyright (C) 2014 vdnguyen

--- a/plugins/plugin-check-linux-bandwidth/doc/plugin-check_linux_bandwidth.rst
+++ b/plugins/plugin-check-linux-bandwidth/doc/plugin-check_linux_bandwidth.rst
@@ -1,4 +1,4 @@
-plugin-check-linux-bandwidth
-============================
+monitoring-plugins-sfl-linux-bandwidth
+======================================
 
 check usage bandwidth per month

--- a/plugins/plugin-check-linux-traffic/debian/changelog
+++ b/plugins/plugin-check-linux-traffic/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-linux-traffic (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-linux-traffic (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-linux-traffic/debian/control
+++ b/plugins/plugin-check-linux-traffic/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-linux-traffic
+Source: monitoring-plugins-sfl-linux-traffic
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-linux-traffic
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-linux-traffic.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-linux-traffic.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-linux-traffic
+Package: monitoring-plugins-sfl-linux-traffic
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-netifaces
 Description: Shinken plugin from SFL. Check traffic on linux hosts using _proc_net_dev

--- a/plugins/plugin-check-linux-traffic/debian/copyright
+++ b/plugins/plugin-check-linux-traffic/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-linux-traffic
-Source: <https://github.com/savoirfairelinux/plugin-check-linux-traffic>
+Upstream-Name: monitoring-plugins-sfl-linux-traffic
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-linux-traffic>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-linux-traffic/doc/plugin-check_linux_traffic.rst
+++ b/plugins/plugin-check-linux-traffic/doc/plugin-check_linux_traffic.rst
@@ -1,4 +1,4 @@
-plugin-check-linux-traffic
-==========================
+monitoring-plugins-sfl-linux-traffic
+====================================
 
 Shinken plugin from SFL. Check traffic on linux hosts using /proc/net/dev

--- a/plugins/plugin-check-mem/debian/changelog
+++ b/plugins/plugin-check-mem/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-mem (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-mem (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-mem/debian/control
+++ b/plugins/plugin-check-mem/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-mem
+Source: monitoring-plugins-sfl-mem
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-mem
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-mem.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-mem.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-mem
+Package: monitoring-plugins-sfl-mem
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Plugin to check memory usage

--- a/plugins/plugin-check-mem/debian/copyright
+++ b/plugins/plugin-check-mem/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-mem
-Source: <https://github.com/savoirfairelinux/plugin-check-mem>
+Upstream-Name: monitoring-plugins-sfl-mem
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-mem>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-mem/doc/plugin-check_mem.rst
+++ b/plugins/plugin-check-mem/doc/plugin-check_mem.rst
@@ -1,3 +1,3 @@
-plugin-check_mem
-================
+monitoring-plugins-sfl-mem
+==========================
 Shinken plugin from SFL. Plugin to check memory usage

--- a/plugins/plugin-check-mpt-status/debian/changelog
+++ b/plugins/plugin-check-mpt-status/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-mpt-status (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-mpt-status (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-mpt-status/debian/control
+++ b/plugins/plugin-check-mpt-status/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-mpt-status
+Source: monitoring-plugins-sfl-mpt-status
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-mpt-status
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-mpt-status.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-mpt-status.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-mpt-status
+Package: monitoring-plugins-sfl-mpt-status
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check mpt HW RAID controllers status

--- a/plugins/plugin-check-mpt-status/debian/copyright
+++ b/plugins/plugin-check-mpt-status/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-mpt-status
-Source: <https://github.com/savoirfairelinux/plugin-check-mpt-status>
+Upstream-Name: monitoring-plugins-sfl-mpt-status
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-mpt-status>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-mpt-status/doc/plugin-check_mpt_status.rst
+++ b/plugins/plugin-check-mpt-status/doc/plugin-check_mpt_status.rst
@@ -1,4 +1,4 @@
-plugin-check-mpt-status
-=======================
+monitoring-plugins-sfl-mpt-status
+=================================
 
 Shinken plugin from SFL. Check mpt HW RAID controllers status

--- a/plugins/plugin-check-openbsd-sysstats-byssh/debian/changelog
+++ b/plugins/plugin-check-openbsd-sysstats-byssh/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-openbsd-sysstats-byssh (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-openbsd-sysstats-byssh (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-openbsd-sysstats-byssh/debian/control
+++ b/plugins/plugin-check-openbsd-sysstats-byssh/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-openbsd-sysstats-byssh
+Source: monitoring-plugins-sfl-openbsd-sysstats-byssh
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-openbsd-sysstats-byssh
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-openbsd-sysstats-byssh.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-openbsd-sysstats-byssh.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-openbsd-sysstats-byssh
+Package: monitoring-plugins-sfl-openbsd-sysstats-byssh
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check OpenBSD system stats using ssh

--- a/plugins/plugin-check-openbsd-sysstats-byssh/debian/copyright
+++ b/plugins/plugin-check-openbsd-sysstats-byssh/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-openbsd-sysstats-byssh
-Source: <https://github.com/savoirfairelinux/plugin-check-openbsd-sysstats-byssh>
+Upstream-Name: monitoring-plugins-sfl-openbsd-sysstats-byssh
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-openbsd-sysstats-byssh>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-openbsd-sysstats-byssh/doc/plugin-check_openbsd_sysstats_byssh.rst
+++ b/plugins/plugin-check-openbsd-sysstats-byssh/doc/plugin-check_openbsd_sysstats_byssh.rst
@@ -1,4 +1,4 @@
-plugin-check-openbsd-sysstats-byssh
-===================================
+monitoring-plugins-sfl-openbsd-sysstats-byssh
+=============================================
 
 Shinken plugin from SFL. Check OpenBSD system stats using ssh

--- a/plugins/plugin-check-openerp/debian/changelog
+++ b/plugins/plugin-check-openerp/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-openerp (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-openerp (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-openerp/debian/control
+++ b/plugins/plugin-check-openerp/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-openerp
+Source: monitoring-plugins-sfl-openerp
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-openerp
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-openerp.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-openerp.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-openerp
+Package: monitoring-plugins-sfl-openerp
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check OpenERP using a web scenario

--- a/plugins/plugin-check-openerp/debian/copyright
+++ b/plugins/plugin-check-openerp/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-openerp
-Source: <https://github.com/savoirfairelinux/plugin-check-openerp>
+Upstream-Name: monitoring-plugins-sfl-openerp
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-openerp>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-openerp/doc/plugin-check_openerp.rst
+++ b/plugins/plugin-check-openerp/doc/plugin-check_openerp.rst
@@ -1,4 +1,4 @@
-plugin-check-openerp
-====================
+monitoring-plugins-sfl-openerp
+==============================
 
 Shinken plugin from SFL. Check OpenERP using a web scenario

--- a/plugins/plugin-check-poller2livestatus/debian/changelog
+++ b/plugins/plugin-check-poller2livestatus/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-poller2livestatus (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-poller2livestatus (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-poller2livestatus/debian/control
+++ b/plugins/plugin-check-poller2livestatus/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-poller2livestatus
+Source: monitoring-plugins-sfl-poller2livestatus
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-poller2livestatus
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-poller2livestatus.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-poller2livestatus.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-poller2livestatus
+Package: monitoring-plugins-sfl-poller2livestatus
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check Shinken from poller to livestatus module

--- a/plugins/plugin-check-poller2livestatus/debian/copyright
+++ b/plugins/plugin-check-poller2livestatus/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-poller2livestatus
-Source: <https://github.com/savoirfairelinux/plugin-check-poller2livestatus>
+Upstream-Name: monitoring-plugins-sfl-poller2livestatus
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-poller2livestatus>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-poller2livestatus/doc/plugin-check_poller2livestatus.rst
+++ b/plugins/plugin-check-poller2livestatus/doc/plugin-check_poller2livestatus.rst
@@ -1,4 +1,4 @@
-plugin-check-poller2livestatus
-==============================
+monitoring-plugins-sfl-poller2livestatus
+========================================
 
 Shinken plugin from SFL. Check Shinken from poller to livestatus module

--- a/plugins/plugin-check-postgresql-lag/debian/changelog
+++ b/plugins/plugin-check-postgresql-lag/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-postgresql-lag (2014.11.14.17.3-1) unstable; urgency=low
+monitoring-plugins-sfl-postgresql-lag (2014.11.14.17.3-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-postgresql-lag/debian/control
+++ b/plugins/plugin-check-postgresql-lag/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-postgresql-lag
+Source: monitoring-plugins-sfl-postgresql-lag
 Section: python
 Priority: optional
 Maintainer: vdnguyen <vanduc.nguyen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-postgresql-lag
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-postgresql-lag.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-postgresql-lag.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-postgresql-lag
+Package: monitoring-plugins-sfl-postgresql-lag
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: check postgresql streaming latency

--- a/plugins/plugin-check-postgresql-lag/debian/copyright
+++ b/plugins/plugin-check-postgresql-lag/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-postgresql-lag
-Source: <https://github.com/savoirfairelinux/plugin-check-postgresql-lag>
+Upstream-Name: monitoring-plugins-sfl-postgresql-lag
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-postgresql-lag>
 
 Files: *
 Copyright: Copyright (C) 2014 vdnguyen

--- a/plugins/plugin-check-postgresql-lag/doc/plugin-check_postgresql_lag.rst
+++ b/plugins/plugin-check-postgresql-lag/doc/plugin-check_postgresql_lag.rst
@@ -1,4 +1,4 @@
-plugin-check-postgresql-lag
-===========================
+monitoring-plugins-sfl-postgresql-lag
+=====================================
 
 check postgresql streaming latency

--- a/plugins/plugin-check-printer-hp-2600n/debian/changelog
+++ b/plugins/plugin-check-printer-hp-2600n/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-printer-hp-2600n (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-printer-hp-2600n (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-printer-hp-2600n/debian/control
+++ b/plugins/plugin-check-printer-hp-2600n/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-printer-hp-2600n
+Source: monitoring-plugins-sfl-printer-hp-2600n
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-printer-hp-2600n
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-printer-hp-2600n.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-printer-hp-2600n.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-printer-hp-2600n
+Package: monitoring-plugins-sfl-printer-hp-2600n
 Architecture: all
 #Depends: python, python-dlnetsnmp
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-lxml

--- a/plugins/plugin-check-printer-hp-2600n/debian/copyright
+++ b/plugins/plugin-check-printer-hp-2600n/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-printer-hp-2600n
-Source: <https://github.com/savoirfairelinux/plugin-check-printer-hp-2600n>
+Upstream-Name: monitoring-plugins-sfl-printer-hp-2600n
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-printer-hp-2600n>
 
 Files: *
 Copyright: 2012 Savoir-faire Linux

--- a/plugins/plugin-check-printer-hp-2600n/doc/plugin-check_printer_hp_2600n.rst
+++ b/plugins/plugin-check-printer-hp-2600n/doc/plugin-check_printer_hp_2600n.rst
@@ -1,4 +1,4 @@
-plugin-check-printer-hp-2600n
-=============================
+monitoring-plugins-sfl-printer-hp-2600n
+=======================================
 
 Shinken plugin from SFL. Check toner level from a hp 2600n printer

--- a/plugins/plugin-check-quebecrencontrescom/debian/changelog
+++ b/plugins/plugin-check-quebecrencontrescom/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-quebecrencontrescom (2014.7.18.12.24-1) unstable; urgency=low
+monitoring-plugins-sfl-quebecrencontrescom (2014.7.18.12.24-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-quebecrencontrescom/debian/control
+++ b/plugins/plugin-check-quebecrencontrescom/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-quebecrencontrescom
+Source: monitoring-plugins-sfl-quebecrencontrescom
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-quebecrencontrescom
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-quebecrencontrescom.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-quebecrencontrescom.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-quebecrencontrescom
+Package: monitoring-plugins-sfl-quebecrencontrescom
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: Checks number of lonely hearts on quebecrencontres.com.

--- a/plugins/plugin-check-quebecrencontrescom/debian/copyright
+++ b/plugins/plugin-check-quebecrencontrescom/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-quebecrencontrescom
-Source: <https://github.com/savoirfairelinux/plugin-check-quebecrencontrescom>
+Upstream-Name: monitoring-plugins-sfl-quebecrencontrescom
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-quebecrencontrescom>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-quebecrencontrescom/doc/plugin-check_quebecrencontrescom.rst
+++ b/plugins/plugin-check-quebecrencontrescom/doc/plugin-check_quebecrencontrescom.rst
@@ -1,4 +1,4 @@
-plugin-check-quebecrencontrescom
-================================
+monitoring-plugins-sfl-quebecrencontrescom
+==========================================
 
 Checks number of lonely hearts on quebecrencontres.com.

--- a/plugins/plugin-check-rancid/debian/changelog
+++ b/plugins/plugin-check-rancid/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-rancid (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-rancid (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-rancid/debian/control
+++ b/plugins/plugin-check-rancid/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-rancid
+Source: monitoring-plugins-sfl-rancid
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-rancid
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-rancid.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-rancid.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-rancid
+Package: monitoring-plugins-sfl-rancid
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-svn
 Description: Check various things from a rancid repo depending on the mode.

--- a/plugins/plugin-check-rancid/debian/copyright
+++ b/plugins/plugin-check-rancid/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-rancid
-Source: <https://github.com/savoirfairelinux/plugin-check-rancid>
+Upstream-Name: monitoring-plugins-sfl-rancid
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-rancid>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-rancid/doc/plugin-check_rancid.rst
+++ b/plugins/plugin-check-rancid/doc/plugin-check_rancid.rst
@@ -1,4 +1,4 @@
-plugin-check_rancid
-===============================
+monitoring-plugins-sfl-rancid
+=============================
 Shinken plugin from SFL.
 Check various things from a rancid repo depending on the mode.

--- a/plugins/plugin-check-reactionner-health/debian/changelog
+++ b/plugins/plugin-check-reactionner-health/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-reactionner-health (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-reactionner-health (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-reactionner-health/debian/control
+++ b/plugins/plugin-check-reactionner-health/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-reactionner-health
+Source: monitoring-plugins-sfl-reactionner-health
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-reactionner-health
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-reactionner-health.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-reactionner-health.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-reactionner-health
+Package: monitoring-plugins-sfl-reactionner-health
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Pseudo crontab to check if a file is edited by shinken reactionner

--- a/plugins/plugin-check-reactionner-health/debian/copyright
+++ b/plugins/plugin-check-reactionner-health/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-reactionner-health
-Source: <https://github.com/savoirfairelinux/plugin-check-reactionner-health>
+Upstream-Name: monitoring-plugins-sfl-reactionner-health
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-reactionner-health>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-reactionner-health/doc/plugin-check_reactionner_health.rst
+++ b/plugins/plugin-check-reactionner-health/doc/plugin-check_reactionner_health.rst
@@ -1,4 +1,4 @@
-plugin-check-reactionner-health
-===============================
+monitoring-plugins-sfl-reactionner-health
+=========================================
 
 Shinken plugin from SFL. Pseudo crontab to check if a file is edited by shinken reactionner

--- a/plugins/plugin-check-redis/debian/changelog
+++ b/plugins/plugin-check-redis/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-redis (2014.10.30.10.42-1) unstable; urgency=low
+monitoring-plugins-sfl-redis (2014.10.30.10.42-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-redis/debian/control
+++ b/plugins/plugin-check-redis/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-redis
+Source: monitoring-plugins-sfl-redis
 Section: python
 Priority: optional
 Maintainer: vdnguyen <vanduc.nguyen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-redis
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-redis.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-redis.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-redis
+Package: monitoring-plugins-sfl-redis
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: check redis data base

--- a/plugins/plugin-check-redis/debian/copyright
+++ b/plugins/plugin-check-redis/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-redis
-Source: <https://github.com/savoirfairelinux/plugin-check-redis>
+Upstream-Name: monitoring-plugins-sfl-redis
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-redis>
 
 Files: *
 Copyright: Copyright (C) 2014 vdnguyen

--- a/plugins/plugin-check-redis/doc/plugin-check_redis.rst
+++ b/plugins/plugin-check-redis/doc/plugin-check_redis.rst
@@ -1,4 +1,4 @@
-plugin-check-redis
-==================
+monitoring-plugins-sfl-redis
+============================
 
 check redis data base

--- a/plugins/plugin-check-reseaucontactcom/debian/changelog
+++ b/plugins/plugin-check-reseaucontactcom/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-reseaucontactcom (2014.7.18.14.29-1) unstable; urgency=low
+monitoring-plugins-sfl-reseaucontactcom (2014.7.18.14.29-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-reseaucontactcom/debian/control
+++ b/plugins/plugin-check-reseaucontactcom/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-reseaucontactcom
+Source: monitoring-plugins-sfl-reseaucontactcom
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-reseaucontactcom
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-reseaucontactcom.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-reseaucontactcom.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-reseaucontactcom
+Package: monitoring-plugins-sfl-reseaucontactcom
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: Checks number of lonely hearts on reseaucontact.com.

--- a/plugins/plugin-check-reseaucontactcom/debian/copyright
+++ b/plugins/plugin-check-reseaucontactcom/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-reseaucontactcom
-Source: <https://github.com/savoirfairelinux/plugin-check-reseaucontactcom>
+Upstream-Name: monitoring-plugins-sfl-reseaucontactcom
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-reseaucontactcom>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-reseaucontactcom/doc/plugin-check_reseaucontactcom.rst
+++ b/plugins/plugin-check-reseaucontactcom/doc/plugin-check_reseaucontactcom.rst
@@ -1,4 +1,4 @@
-plugin-check-reseaucontactcom
-=============================
+monitoring-plugins-sfl-reseaucontactcom
+=======================================
 
 Checks number of lonely hearts on reseaucontact.com.

--- a/plugins/plugin-check-samba/debian/changelog
+++ b/plugins/plugin-check-samba/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-samba (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-samba (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-samba/debian/control
+++ b/plugins/plugin-check-samba/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-samba
+Source: monitoring-plugins-sfl-samba
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-samba
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-samba.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-samba.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-samba
+Package: monitoring-plugins-sfl-samba
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-pyasn1
 Description: Shinken plugin from SFL. Samba server check

--- a/plugins/plugin-check-samba/debian/copyright
+++ b/plugins/plugin-check-samba/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-samba
-Source: <https://github.com/savoirfairelinux/plugin-check-samba>
+Upstream-Name: monitoring-plugins-sfl-samba
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-samba>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-samba/doc/plugin-check_samba.rst
+++ b/plugins/plugin-check-samba/doc/plugin-check_samba.rst
@@ -1,4 +1,4 @@
-plugin-check-samba
-==================
+monitoring-plugins-sfl-samba
+============================
 
 Shinken plugin from SFL. Samba server check

--- a/plugins/plugin-check-samba/smb/utils/pyDes.py
+++ b/plugins/plugin-check-samba/smb/utils/pyDes.py
@@ -6,7 +6,7 @@
 # Date:     16th March, 2009
 # Verion:   2.0.0
 # License:  Public Domain - free to do as you wish
-# Homepage: http://twhiteman.netfirms.com/des.html
+# Homepage: https://github.com/savoirfairelinux/monitoring-tools
 #
 # This is a pure python implementation of the DES encryption algorithm.
 # It's pure python to avoid portability issues, since most DES 

--- a/plugins/plugin-check-selenium/debian/changelog
+++ b/plugins/plugin-check-selenium/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-selenium (2014.8.1.10.36-1) unstable; urgency=low
+monitoring-plugins-sfl-selenium (2014.8.1.10.36-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-selenium/debian/control
+++ b/plugins/plugin-check-selenium/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-selenium
+Source: monitoring-plugins-sfl-selenium
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-selenium
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-selenium.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-selenium.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-selenium
+Package: monitoring-plugins-sfl-selenium
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Web tests using Selenium

--- a/plugins/plugin-check-selenium/debian/copyright
+++ b/plugins/plugin-check-selenium/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-selenium
-Source: <https://github.com/savoirfairelinux/plugin-check-selenium>
+Upstream-Name: monitoring-plugins-sfl-selenium
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-selenium>
 
 Files: *
 Copyright: Copyright (C) 2014 Thibault Cohen

--- a/plugins/plugin-check-selenium/doc/plugin-check_selenium.rst
+++ b/plugins/plugin-check-selenium/doc/plugin-check_selenium.rst
@@ -1,6 +1,6 @@
-=====================
-plugin-check-selenium
-=====================
+===============================
+monitoring-plugins-sfl-selenium
+===============================
 
 Web scenario tests using Selenium
 

--- a/plugins/plugin-check-site-health/debian/changelog
+++ b/plugins/plugin-check-site-health/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-site-health (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-site-health (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-site-health/debian/control
+++ b/plugins/plugin-check-site-health/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-site-health
+Source: monitoring-plugins-sfl-site-health
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-site-health
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-site-health.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-site-health.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-site-health
+Package: monitoring-plugins-sfl-site-health
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Browse web site to find broken links

--- a/plugins/plugin-check-site-health/debian/copyright
+++ b/plugins/plugin-check-site-health/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-site-health
-Source: <https://github.com/savoirfairelinux/plugin-check-site-health>
+Upstream-Name: monitoring-plugins-sfl-site-health
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-site-health>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-site-health/doc/plugin-check_site_health.rst
+++ b/plugins/plugin-check-site-health/doc/plugin-check_site_health.rst
@@ -1,4 +1,4 @@
-plugin-check-site-health
-========================
+monitoring-plugins-sfl-site-health
+==================================
 
 Shinken plugin from SFL. Browse web site to find broken links

--- a/plugins/plugin-check-smtp-success-ratio/debian/changelog
+++ b/plugins/plugin-check-smtp-success-ratio/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-smtp-success-ratio (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-smtp-success-ratio (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-smtp-success-ratio/debian/control
+++ b/plugins/plugin-check-smtp-success-ratio/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-smtp-success-ratio
+Source: monitoring-plugins-sfl-smtp-success-ratio
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-smtp-success-ratio
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-smtp-success-ratio.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-smtp-success-ratio.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-smtp-success-ratio
+Package: monitoring-plugins-sfl-smtp-success-ratio
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Given a maillog, checks for a good ratio of sent versus total emails.

--- a/plugins/plugin-check-smtp-success-ratio/debian/copyright
+++ b/plugins/plugin-check-smtp-success-ratio/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-smtp-success-ratio
-Source: <https://github.com/savoirfairelinux/plugin-check-smtp-success-ratio>
+Upstream-Name: monitoring-plugins-sfl-smtp-success-ratio
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-smtp-success-ratio>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-smtp-success-ratio/doc/plugin-check_smtp_success_ratio.rst
+++ b/plugins/plugin-check-smtp-success-ratio/doc/plugin-check_smtp_success_ratio.rst
@@ -1,4 +1,4 @@
-plugin-check-smtp-success-ratio
-===============================
+monitoring-plugins-sfl-smtp-success-ratio
+=========================================
 
 Shinken plugin from SFL. Given a maillog, checks for a good ratio of sent versus total emails.

--- a/plugins/plugin-check-snmp-interface/debian/changelog
+++ b/plugins/plugin-check-snmp-interface/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-snmp-interface (2014.11.17.11.1-1) unstable; urgency=low
+monitoring-plugins-sfl-snmp-interface (2014.11.17.11.1-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-snmp-interface/debian/control
+++ b/plugins/plugin-check-snmp-interface/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-snmp-interface
+Source: monitoring-plugins-sfl-snmp-interface
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-snmp-interface
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-snmp-interface.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-snmp-interface.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-snmp-interface
+Package: monitoring-plugins-sfl-snmp-interface
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: This plugin check interface traffic using SNMP

--- a/plugins/plugin-check-snmp-interface/debian/copyright
+++ b/plugins/plugin-check-snmp-interface/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-snmp-interface
-Source: <https://github.com/savoirfairelinux/plugin-check-snmp-interface>
+Upstream-Name: monitoring-plugins-sfl-snmp-interface
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-snmp-interface>
 
 Files: *
 Copyright: Copyright (C) 2014 Thibault Cohen

--- a/plugins/plugin-check-snmp-interface/doc/plugin-check_snmp_interface.rst
+++ b/plugins/plugin-check-snmp-interface/doc/plugin-check_snmp_interface.rst
@@ -1,4 +1,4 @@
-plugin-check-snmp-interface
-===========================
+monitoring-plugins-sfl-snmp-interface
+=====================================
 
 This plugin check interface traffic using SNMP

--- a/plugins/plugin-check-spa2102/debian/changelog
+++ b/plugins/plugin-check-spa2102/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-spa2102 (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-spa2102 (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-spa2102/debian/control
+++ b/plugins/plugin-check-spa2102/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-spa2102
+Source: monitoring-plugins-sfl-spa2102
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-spa2102
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-spa2102.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-spa2102.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-spa2102
+Package: monitoring-plugins-sfl-spa2102
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-lxml
 Description: Shinken plugin from SFL. Check Linksys SPA-2102 status

--- a/plugins/plugin-check-spa2102/debian/copyright
+++ b/plugins/plugin-check-spa2102/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-spa2102
-Source: <https://github.com/savoirfairelinux/plugin-check-spa2102>
+Upstream-Name: monitoring-plugins-sfl-spa2102
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-spa2102>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-spa2102/doc/plugin-check_spa2102.rst
+++ b/plugins/plugin-check-spa2102/doc/plugin-check_spa2102.rst
@@ -1,4 +1,4 @@
-plugin-check-spa2102
-====================
+monitoring-plugins-sfl-spa2102
+==============================
 
 Shinken plugin from SFL. Check Linksys SPA-2102 status

--- a/plugins/plugin-check-stm-metro-montreal/debian/changelog
+++ b/plugins/plugin-check-stm-metro-montreal/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-stm-metro-montreal (2014.7.18.11.16-1) unstable; urgency=low
+monitoring-plugins-sfl-stm-metro-montreal (2014.7.18.11.16-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-stm-metro-montreal/debian/control
+++ b/plugins/plugin-check-stm-metro-montreal/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-stm-metro-montreal
+Source: monitoring-plugins-sfl-stm-metro-montreal
 Section: python
 Priority: optional
 Maintainer: Matthieu Caneill <matthieu.caneill@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-stm-metro-montreal
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-stm-metro-montreal.git
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-stm-metro-montreal.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-stm-metro-montreal
+Package: monitoring-plugins-sfl-stm-metro-montreal
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins, python-lxml
 Description: Checks the current state of the metro in Montreal.

--- a/plugins/plugin-check-stm-metro-montreal/debian/copyright
+++ b/plugins/plugin-check-stm-metro-montreal/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-stm-metro-montreal
-Source: <https://github.com/savoirfairelinux/plugin-check-stm-metro-montreal>
+Upstream-Name: monitoring-plugins-sfl-stm-metro-montreal
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-stm-metro-montreal>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-stm-metro-montreal/doc/plugin-check_stm_metro_montreal.rst
+++ b/plugins/plugin-check-stm-metro-montreal/doc/plugin-check_stm_metro_montreal.rst
@@ -1,4 +1,4 @@
-plugin-check-stm-metro-montreal
-===============================
+monitoring-plugins-sfl-stm-metro-montreal
+=========================================
 
 Checks the current state of the metro in Montreal.

--- a/plugins/plugin-check-tripplite-ups/debian/changelog
+++ b/plugins/plugin-check-tripplite-ups/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-tripplite-ups (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-tripplite-ups (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-tripplite-ups/debian/control
+++ b/plugins/plugin-check-tripplite-ups/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-tripplite-ups
+Source: monitoring-plugins-sfl-tripplite-ups
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-tripplite-ups
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-tripplite-ups.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-tripplite-ups.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-tripplite-ups
+Package: monitoring-plugins-sfl-tripplite-ups
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check Tripplite UPSs

--- a/plugins/plugin-check-tripplite-ups/debian/copyright
+++ b/plugins/plugin-check-tripplite-ups/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-tripplite-ups
-Source: <https://github.com/savoirfairelinux/plugin-check-tripplite-ups>
+Upstream-Name: monitoring-plugins-sfl-tripplite-ups
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-tripplite-ups>
 
 Files: *
 Copyright: 2012 Savoir-Faire Linux Inc. 

--- a/plugins/plugin-check-tripplite-ups/doc/plugin-check_tripplite_ups.rst
+++ b/plugins/plugin-check-tripplite-ups/doc/plugin-check_tripplite_ups.rst
@@ -1,4 +1,4 @@
-plugin-check-tripplite-ups
-==========================
+monitoring-plugins-sfl-tripplite-ups
+====================================
 
 Shinken plugin from SFL. Check Tripplite UPSs

--- a/plugins/plugin-check-wanpipe/debian/changelog
+++ b/plugins/plugin-check-wanpipe/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-wanpipe (2014.07.14.10.32-1) unstable; urgency=low
+monitoring-plugins-sfl-wanpipe (2014.07.14.10.32-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-wanpipe/debian/control
+++ b/plugins/plugin-check-wanpipe/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-wanpipe
+Source: monitoring-plugins-sfl-wanpipe
 Section: python
 Priority: optional
 Maintainer: Thibault Cohen <thibault.cohen@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-wanpipe
-#Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-wanpipe.git
-#Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-wanpipe.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+#Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+#Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-wanpipe
+Package: monitoring-plugins-sfl-wanpipe
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Shinken plugin from SFL. Check channels in error with wanpipe

--- a/plugins/plugin-check-wanpipe/debian/copyright
+++ b/plugins/plugin-check-wanpipe/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-wanpipe
-Source: <https://github.com/savoirfairelinux/plugin-check-wanpipe>
+Upstream-Name: monitoring-plugins-sfl-wanpipe
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-wanpipe>
 
 Files: *
 Copyright: 2013 Savoir-Faire Linux Inc.

--- a/plugins/plugin-check-wanpipe/doc/plugin-check_wanpipe.rst
+++ b/plugins/plugin-check-wanpipe/doc/plugin-check_wanpipe.rst
@@ -1,4 +1,4 @@
-plugin-check-wanpipe
-====================
+monitoring-plugins-sfl-wanpipe
+==============================
 
 Shinken plugin from SFL. Check channels in error with wanpipe

--- a/plugins/plugin-check-x224/debian/changelog
+++ b/plugins/plugin-check-x224/debian/changelog
@@ -1,4 +1,4 @@
-plugin-check-x224 (2014.9.17.10.45-1) unstable; urgency=low
+monitoring-plugins-sfl-x224 (2014.9.17.10.45-1) unstable; urgency=low
 
   * Initial release
 

--- a/plugins/plugin-check-x224/debian/control
+++ b/plugins/plugin-check-x224/debian/control
@@ -1,14 +1,14 @@
-Source: plugin-check-x224
+Source: monitoring-plugins-sfl-x224
 Section: python
 Priority: optional
 Maintainer: Grégory Starck <gregory.starck@savoirfairelinux.com>
 Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
-Homepage: https://github.com/savoirfairelinux/plugin-check-x224
-Vcs-Git: git://anonscm.debian.org/collab-maint/plugin-check-x224
-Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/plugin-check-x224.git;a=summary
+Homepage: https://github.com/savoirfairelinux/monitoring-tools
+Vcs-Git: git@github.com:savoirfairelinux/monitoring-tools.git
+Vcs-Browser: https://github.com/savoirfairelinux/monitoring-tools.git
 
-Package: plugin-check-x224
+Package: monitoring-plugins-sfl-x224
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, python-shinkenplugins
 Description: Checks an x224 (RDP) service.

--- a/plugins/plugin-check-x224/debian/copyright
+++ b/plugins/plugin-check-x224/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: plugin-check-x224
-Source: <https://github.com/savoirfairelinux/plugin-check-x224>
+Upstream-Name: monitoring-plugins-sfl-x224
+Source: <https://github.com/savoirfairelinux/monitoring-plugins-sfl-x224>
 
 Files: *
 Copyright: Copyright (C) 2014 Savoir-faire Linux, Inc.

--- a/plugins/plugin-check-x224/doc/plugin-check_x224.rst
+++ b/plugins/plugin-check-x224/doc/plugin-check_x224.rst
@@ -1,4 +1,4 @@
-plugin-check-x224
-=================
+monitoring-plugins-sfl-x224
+===========================
 
 Checks an x224 (RDP) service.


### PR DESCRIPTION
Please review it. We need to rename everything in OBS then.
- The name is closer to monitoring-plugins (formerly nagios-plugins) package so that we keep some standard
- Monitoring-plugins is a great name because it's very generic and does not rely on a backed (Shinken etc), plugin-check-XXX is not self explainatory. 
- monitoring-plugins-sfl-XXX is more convenient for package listing / search. It looks like it's a sub category of monitoring-plugins which  is clear and prevent name conflicts. 
