### PR TITLE
Update: KeyStone and Glance check path

### DIFF
--- a/packs/linux-glance/pack/commands.cfg
+++ b/packs/linux-glance/pack/commands.cfg
@@ -1,4 +1,4 @@
 define command {
        command_name        check_glance
-       command_line        $PLUGINSDIR$/check_glance -U $_HOSTOS_AUTH_URL$ -u $_HOSTOS_USERNAME$ -p $_HOSTOS_PASSWORD$ -t $_HOSTOS_TENANT_NAME$ -e $_HOSTOS_GLANCE_URL$
+       command_line        /usr/local/bin/check_glance -U $_HOSTOS_AUTH_URL$ -u $_HOSTOS_USERNAME$ -p $_HOSTOS_PASSWORD$ -t $_HOSTOS_TENANT_NAME$ -e $_HOSTOS_GLANCE_URL$
 }

--- a/packs/linux-keystone/pack/commands.cfg
+++ b/packs/linux-keystone/pack/commands.cfg
@@ -6,5 +6,5 @@
 
 define command {
     command_name    check_keystone
-    command_line    $PLUGINSDIR$/check_keystone -U $_HOSTOS_AUTH_URL$ -u $_HOSTOS_USERNAME$ -p $_HOSTOS_PASSWORD$ -t $_HOSTOS_TENANT_NAME$ -s $_HOSTKS_SERVICES$
+    command_line    /usr/local/bin/check_keystone -U $_HOSTOS_AUTH_URL$ -u $_HOSTOS_USERNAME$ -p $_HOSTOS_PASSWORD$ -t $_HOSTOS_TENANT_NAME$ -s $_HOSTKS_SERVICES$
 }


### PR DESCRIPTION
Now that plugins are using a good setup.py the check script is installed, by default, in /usr/local/bin

Use that accordingly in the packs.